### PR TITLE
bower update

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,5 +1,5 @@
 {
   "name": "scaleapp",
   "version": "0.3.8",
-  "main": "./bundles/scaleApp.js"
+  "main": "./dist/scaleApp.js"
 }


### PR DESCRIPTION
Changed component.json file for bower. ScaleApp.js is not in `bundle` folder anymore (`dist` folder currently)
